### PR TITLE
feat: add in media downloading

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - master
+
   pull_request:
-    branches:
-      - master
+    types: [opened, synchronize, reopened]
+
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ postgres_data
 .vscode
 ollama
 data
+media

--- a/api/backend/job/models/job_options.py
+++ b/api/backend/job/models/job_options.py
@@ -12,3 +12,4 @@ class JobOptions(BaseModel):
     custom_headers: dict[str, Any] = {}
     proxies: list[str] = []
     site_map: Optional[SiteMap] = None
+    collect_media: bool = False

--- a/api/backend/job/scraping/collect_media.py
+++ b/api/backend/job/scraping/collect_media.py
@@ -1,0 +1,91 @@
+import os
+import requests
+from pathlib import Path
+from selenium.webdriver.common.by import By
+from seleniumwire import webdriver
+from urllib.parse import urlparse
+
+from api.backend.utils import LOG
+
+
+def collect_media(driver: webdriver.Chrome):
+    media_types = {
+        "images": "img",
+        "videos": "video",
+        "audio": "audio",
+        "pdfs": 'a[href$=".pdf"]',
+        "documents": 'a[href$=".doc"], a[href$=".docx"], a[href$=".txt"], a[href$=".rtf"]',
+        "presentations": 'a[href$=".ppt"], a[href$=".pptx"]',
+        "spreadsheets": 'a[href$=".xls"], a[href$=".xlsx"], a[href$=".csv"]',
+    }
+
+    base_dir = Path("media")
+    base_dir.mkdir(exist_ok=True)
+
+    media_urls = {}
+
+    for media_type, selector in media_types.items():
+        elements = driver.find_elements(By.CSS_SELECTOR, selector)
+        urls: list[dict[str, str]] = []
+
+        media_dir = base_dir / media_type
+        media_dir.mkdir(exist_ok=True)
+
+        for element in elements:
+            if media_type == "images":
+                url = element.get_attribute("src")
+            elif media_type == "videos":
+                url = element.get_attribute("src") or element.get_attribute("data-src")
+            else:
+                url = element.get_attribute("href")
+
+            if url and url.startswith(("http://", "https://")):
+                try:
+                    filename = os.path.basename(urlparse(url).path)
+
+                    if not filename:
+                        filename = f"{media_type}_{len(urls)}"
+
+                        if media_type == "images":
+                            filename += ".jpg"
+                        elif media_type == "videos":
+                            filename += ".mp4"
+                        elif media_type == "audio":
+                            filename += ".mp3"
+                        elif media_type == "pdfs":
+                            filename += ".pdf"
+                        elif media_type == "documents":
+                            filename += ".doc"
+                        elif media_type == "presentations":
+                            filename += ".ppt"
+                        elif media_type == "spreadsheets":
+                            filename += ".xls"
+
+                    response = requests.get(url, stream=True)
+                    response.raise_for_status()
+
+                    # Save the file
+                    file_path = media_dir / filename
+                    with open(file_path, "wb") as f:
+                        for chunk in response.iter_content(chunk_size=8192):
+                            if chunk:
+                                f.write(chunk)
+
+                    urls.append({"url": url, "local_path": str(file_path)})
+                    LOG.info(f"Downloaded {filename} to {file_path}")
+
+                except Exception as e:
+                    LOG.error(f"Error downloading {url}: {str(e)}")
+                    continue
+
+        media_urls[media_type] = urls
+
+    with open(base_dir / "download_summary.txt", "w") as f:
+        for media_type, downloads in media_urls.items():
+            if downloads:
+                f.write(f"\n=== {media_type.upper()} ===\n")
+                for download in downloads:
+                    f.write(f"URL: {download['url']}\n")
+                    f.write(f"Saved to: {download['local_path']}\n\n")
+
+    return media_urls

--- a/api/backend/job/scraping/scraping_utils.py
+++ b/api/backend/job/scraping/scraping_utils.py
@@ -1,13 +1,19 @@
 import time
 from typing import cast
 
-from selenium import webdriver
+from seleniumwire import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
+from api.backend.utils import LOG
 
-def scrape_content(driver: webdriver.Chrome, pages: set[tuple[str, str]]):
+from api.backend.job.scraping.collect_media import collect_media as collect_media_utils
+
+
+def scrape_content(
+    driver: webdriver.Chrome, pages: set[tuple[str, str]], collect_media: bool
+):
     _ = WebDriverWait(driver, 10).until(
         EC.presence_of_element_located((By.TAG_NAME, "body"))
     )
@@ -27,4 +33,9 @@ def scrape_content(driver: webdriver.Chrome, pages: set[tuple[str, str]]):
         last_height = new_height
 
     pages.add((driver.page_source, driver.current_url))
+
+    if collect_media:
+        LOG.info("Collecting media")
+        collect_media_utils(driver)
+
     return driver.page_source

--- a/api/backend/scraping.py
+++ b/api/backend/scraping.py
@@ -104,6 +104,7 @@ async def make_site_request(
     original_url: str = "",
     proxies: Optional[list[str]] = [],
     site_map: Optional[dict[str, Any]] = None,
+    collect_media: bool = False,
 ) -> None:
     """Make basic `GET` request to site using Selenium."""
     # Check if URL has already been visited
@@ -124,7 +125,7 @@ async def make_site_request(
         visited_urls.add(url)
         visited_urls.add(final_url)
 
-        page_source = scrape_content(driver, pages)
+        page_source = scrape_content(driver, pages, collect_media)
 
         if site_map:
             LOG.info("Site map: %s", site_map)
@@ -197,6 +198,7 @@ async def scrape(
     multi_page_scrape: bool = False,
     proxies: Optional[list[str]] = [],
     site_map: Optional[dict[str, Any]] = None,
+    collect_media: bool = False,
 ):
     visited_urls: set[str] = set()
     pages: set[tuple[str, str]] = set()
@@ -210,6 +212,7 @@ async def scrape(
         original_url=url,
         proxies=proxies,
         site_map=site_map,
+        collect_media=collect_media,
     )
 
     elements: list[dict[str, dict[str, list[CapturedElement]]]] = list()

--- a/api/backend/worker/job_worker.py
+++ b/api/backend/worker/job_worker.py
@@ -27,6 +27,7 @@ async def process_job():
                 job["job_options"]["multi_page_scrape"],
                 job["job_options"]["proxies"],
                 job["job_options"]["site_map"],
+                job["job_options"]["collect_media"],
             )
             LOG.info(
                 f"Scraped result for url: {job['url']}, with elements: {job['elements']}\n{scraped}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - 8000:8000
     volumes:
       - "$PWD/data:/project/data"
+      - "$PWD/media:/project/media"
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - web

--- a/src/components/submit/job-submitter/job-submitter-options/job-submitter-options.tsx
+++ b/src/components/submit/job-submitter/job-submitter-options/job-submitter-options.tsx
@@ -1,7 +1,6 @@
 import { RawJobOptions } from "@/types/job";
 import { Box, FormControlLabel, Checkbox, TextField } from "@mui/material";
 import { Dispatch, SetStateAction } from "react";
-import { useJobSubmitterProvider } from "../provider";
 
 export type JobSubmitterOptionsProps = {
   jobOptions: RawJobOptions;
@@ -40,6 +39,13 @@ export const JobSubmitterOptions = ({
     setJobOptions((prevJobOptions) => ({
       ...prevJobOptions,
       custom_headers: e.target.value,
+    }));
+  };
+
+  const handleCollectMediaChange = () => {
+    setJobOptions((prevJobOptions) => ({
+      ...prevJobOptions,
+      collect_media: !prevJobOptions.collect_media,
     }));
   };
 
@@ -95,6 +101,15 @@ export const JobSubmitterOptions = ({
             />
           }
         ></FormControlLabel>
+        <FormControlLabel
+          label="Collect Media"
+          control={
+            <Checkbox
+              checked={jobOptions.collect_media}
+              onChange={handleCollectMediaChange}
+            />
+          }
+        />
       </div>
       {customJSONSelected ? (
         <div id="custom-json" className="pl-2 pr-2 pb-2">

--- a/src/components/submit/job-submitter/job-submitter.tsx
+++ b/src/components/submit/job-submitter/job-submitter.tsx
@@ -15,6 +15,7 @@ const initialJobOptions: RawJobOptions = {
   multi_page_scrape: false,
   custom_headers: null,
   proxies: null,
+  collect_media: false,
 };
 
 export const JobSubmitter = () => {

--- a/src/lib/helpers/parse-job-options.ts
+++ b/src/lib/helpers/parse-job-options.ts
@@ -11,11 +11,11 @@ export const parseJobOptions = (
 ) => {
   if (job_options) {
     const jsonOptions = JSON.parse(job_options as string);
-    console.log(jsonOptions);
     const newJobOptions: RawJobOptions = {
       multi_page_scrape: false,
       custom_headers: null,
       proxies: null,
+      collect_media: false,
     };
 
     if (

--- a/src/services/api-service/functions/submit-job.ts
+++ b/src/services/api-service/functions/submit-job.ts
@@ -19,6 +19,7 @@ export const submitJob = async (
         time_created: new Date().toISOString(),
         job_options: {
           ...jobOptions,
+          collect_media: jobOptions.collect_media || false,
           custom_headers: customHeaders || {},
           proxies: jobOptions.proxies ? jobOptions.proxies.split(",") : [],
           site_map: siteMap,

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -23,6 +23,7 @@ export type RawJobOptions = {
   multi_page_scrape: boolean;
   custom_headers: string | null;
   proxies: string | null;
+  collect_media: boolean;
 };
 
 export type ActionOption = "click" | "input";


### PR DESCRIPTION
# ✨ Add Media Collection to Scraping Pipeline

## Summary

This PR introduces the `collect_media` function, which enhances scraping capabilities by automatically detecting and downloading various types of media assets from a web page using a Selenium-controlled browser session.

## Screenshots
![image](https://github.com/user-attachments/assets/568c5f5a-ab32-49e9-ae5c-74375c9937c4)

## 🔧 Features

### Supported Media Types:
- Images (`<img>`)
- Videos (`<video>`)
- Audio files (`<audio>`)
- PDFs (`<a href="*.pdf">`)
- Documents (`.doc`, `.docx`, `.txt`, `.rtf`)
- Presentations (`.ppt`, `.pptx`)
- Spreadsheets (`.xls`, `.xlsx`, `.csv`)

### Functionality:
- Uses CSS selectors to find elements containing media links.
- Downloads each valid media file (HTTP/HTTPS only).
- Saves all assets to a structured `media/` directory, grouped by media type.
- Writes a `download_summary.txt` with the original URLs and their local file paths.

### Error Handling:
- Skips failed downloads and logs the error.
- Generates fallback filenames when none are detected in the URL.